### PR TITLE
Fix import syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Then add the plugin to your webpack config. For example:
 
 #### webpack.config.js
 ```js
-const { WebManifestPlugin } = require("webpack-webmanifest-plugin");
+const WebManifestPlugin = require("webpack-webmanifest-plugin");
 
 module.exports = {
   module: {


### PR DESCRIPTION
I found that last version export `WebManifestPlugin` as a default export, not named export