### PR TITLE
Fix for windows paths

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -5,7 +5,7 @@ function getImportIcons(icons, loaderContext) {
     const code = [];
 
     for (const icon of icons) {
-      const dep = `require('${path.resolve(loaderContext.context, icon.src)}')`;
+      const dep = `require(${JSON.stringify(path.resolve(loaderContext.context, icon.src))})`;
 
       if (!code.includes(dep)) {
         code.push(dep);


### PR DESCRIPTION
The backslashes on Windows were being interpreted as escape sequences when embedded in JS code.